### PR TITLE
Allow running tap multiple times the same day

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 ## History
 
+### 0.1.1 (2023-03-27)
+
+- Allow running tap multiple times the same day
+- Add missing package prefix to timedelta call
+- Collect all data in single run
+
 ### 0.1.0 (2021-04-06)
 
 Initial release

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/tap_exchangeratehost/__init__.py
+++ b/tap_exchangeratehost/__init__.py
@@ -46,7 +46,7 @@ def do_sync(base, start_date, end_date=None):
 
     if not end_date:
         end_date = (
-            datetime.date.today() + timedelta(days=1)).strftime(DATE_FORMAT)
+            datetime.date.today() + datetime.timedelta(days=1)).strftime(DATE_FORMAT)
 
     params = {
         "base": base,


### PR DESCRIPTION
start_day record can be missing in the resultset, if everything has already been extracted. Prevent errors like `KeyError: '2023-03-28'`